### PR TITLE
Not able to show toastr at bottom of page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ And then execute:
 ## Usage
 
 Add to your application.js and application.css:
-  
+
     //= require toastr_rails
 
-You can put this in your layout/application.html file if you want to chach flash messages in a toast: 
+You can put this in your layout/application.html file if you want to chach flash messages in a toast:
 
     = render 'toastr_rails/flash'
 
@@ -43,9 +43,17 @@ You can put this in your layout/application.html file if you want to chach flash
       "hideMethod": "fadeOut"
     };
 
-    // css
+## toastr placement
+
+    // add this to your application.css
+    if you want to place toastr to top
     #toast-container{
       top: 70px;
+    }
+
+    if you want to place toastr to bottom
+    #toast-container{
+      bottom: 0px
     }
 
 For all other options you can visit [http://codeseven.github.io/toastr/](http://codeseven.github.io/toastr/)

--- a/app/assets/styleseets/toastr_rails.scss
+++ b/app/assets/styleseets/toastr_rails.scss
@@ -1,5 +1,1 @@
 @import 'toastr';
-
-#toast-container{
-  top: 70px;
-}


### PR DESCRIPTION
Adding 

```
 #toast-container{
   top: 70px;
 }
```

by default will not allow toastr to be show at bottom of the page. It would be difficult to override the css and show toast-container to bottom of the page. But instead we could inform the user to paste the css code as shown in toastr placement of my README.md file
